### PR TITLE
chore: fix script for non-replicated clusters and add avg item size for ddb results

### DIFF
--- a/internal/resources/dynamodb.go
+++ b/internal/resources/dynamodb.go
@@ -82,12 +82,19 @@ func (ddb *DynamoDb) GetAll() ([]*ResourceSummary, error) {
 			ttlEnabled = true
 		}
 
+		avg_item_size := int64(0)
+		if *dRsp.Table.ItemCount != 0 {
+			avg_item_size = *dRsp.Table.TableSizeBytes / *dRsp.Table.ItemCount
+		}
+
 		returnList = append(returnList, &ResourceSummary{
 			ID:   table,
 			Type: "AWS::DynamoDB::Table",
 			AdditionalData: map[string]string{
-				"ttl_enabled": strconv.FormatBool(ttlEnabled),
-				"item_count":  strconv.FormatInt(*dRsp.Table.ItemCount, 10),
+				"ttl_enabled":   strconv.FormatBool(ttlEnabled),
+				"item_count":    strconv.FormatInt(*dRsp.Table.ItemCount, 10),
+				"table_size_bytes": strconv.FormatInt(*dRsp.Table.TableSizeBytes, 10),
+				"avg_item_size_bytes": strconv.FormatInt(avg_item_size, 10),
 			},
 			Resource: ddb,
 		})

--- a/internal/resources/elasticache.go
+++ b/internal/resources/elasticache.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"

--- a/internal/resources/elasticache.go
+++ b/internal/resources/elasticache.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
@@ -71,7 +72,7 @@ func (ec *Elasticache) GetAll() ([]*ResourceSummary, error) {
 			case "redis":
 				// Determine if redis node is in cluster mode or not
 				clusterModeEnabled := false
-				if len(
+				if c.ReplicationGroupId == nil || len(
 					strings.Split(
 						strings.TrimPrefix(*c.CacheClusterId, *c.ReplicationGroupId+"-"),
 						"-",
@@ -87,7 +88,7 @@ func (ec *Elasticache) GetAll() ([]*ResourceSummary, error) {
 					ID:   *c.CacheClusterId,
 					Type: "AWS::Elasticache::RedisNode",
 					AdditionalData: map[string]string{
-						"cluster_id":           *c.ReplicationGroupId,
+						"cluster_id":           *c.CacheClusterId,
 						"engine":               *c.Engine,
 						"cache_node_type":      *c.CacheNodeType,
 						"preferred_az":         *c.PreferredAvailabilityZone,


### PR DESCRIPTION
- I had a Redis EC cluster without replication which resulted in the nil ```replicationGroupID``` to be dereferenced causing:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102dc7960]

goroutine 1 [running]:
github.com/momentohq/aws-usage-analyzer/internal/resources.(*Elasticache).GetAll(0x140000b41e8)
	/Users/pratik/sandbox/aws-usage-analyzer/internal/resources/elasticache.go:76 +0x270
```

- Added avg item size for DDB entries and ran for alpha; looks like

```
[
{"ResourceId":"cache-admin-cell-config-v2-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""0""","Metrics":"""item_count"":""0"""},
{"ResourceId":"cache-admin-state-machine-states-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""1542""","Metrics":"""item_count"":""2"""},
{"ResourceId":"cache-partitions-v2-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""347""","Metrics":"""item_count"":""5"""},
{"ResourceId":"cache-pools-v2-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""699""","Metrics":"""item_count"":""532"""},
{"ResourceId":"cache-replica-groups-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""359""","Metrics":"""item_count"":""2"""},
{"ResourceId":"customer-config-v2-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""236""","Metrics":"""item_count"":""18"""},
{"ResourceId":"lock-v2-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""115""","Metrics":"""item_count"":""1"""},
{"ResourceId":"persistent-store-index-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""122""","Metrics":"""item_count"":""24"""},
{"ResourceId":"refresh-token-history-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""181""","Metrics":"""item_count"":""2"""},
{"ResourceId":"signing-keys-v2-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""540""","Metrics":"""item_count"":""2"""},
{"ResourceId":"vector-clusters-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""0""","Metrics":"""item_count"":""0"""},
{"ResourceId":"vector-indices-dev","Type":"AWS::DynamoDB::Table","AdditionalData":""{""avg_item_size_bytes"":""0""","Metrics":"""item_count"":""0"""}
]
```